### PR TITLE
Unpin browserslist and isbot

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
 		"@types/object-path": "^0.11.1",
 		"@types/semver": "^7.3.13",
 		"@types/ua-parser-js": "^0.7.36",
-		"browserslist": "4.21.4",
+		"browserslist": "^4.21.4",
 		"caniuse-lite": "^1.0.30001447",
-		"isbot": "3.6.5",
+		"isbot": "^3.6.5",
 		"object-path": "^0.11.8",
 		"semver": "^7.3.8",
 		"ua-parser-js": "^1.0.33"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ specifiers:
   '@wessberg/prettier-config': 1.0.0
   '@wessberg/ts-config': ^3.1.0
   ava: ^5.1.1
-  browserslist: 4.21.4
+  browserslist: ^4.21.4
   caniuse-lite: ^1.0.30001447
   eslint: ^8.32.0
   eslint-config-prettier: ^8.6.0
   eslint-plugin-import: ^2.27.5
   eslint-plugin-jsdoc: ^39.6.7
   husky: ^8.0.3
-  isbot: 3.6.5
+  isbot: ^3.6.5
   np: 7.6.3
   npm-check-updates: ^16.6.2
   object-path: ^0.11.8


### PR DESCRIPTION
Allow for better dependency deduplication in consumers by using a range for browserslist and isbot dependencies.

Browserslist is now on 4.21.5, so the exact dependency here is currently not the latest.