### PR TITLE
fix: remove duplicate entry from ES2022 features

### DIFF
--- a/src/browserslist-generator/ecma-version.ts
+++ b/src/browserslist-generator/ecma-version.ts
@@ -90,7 +90,6 @@ export const ES2021_FEATURES: string[] = [
 export const ES2022_FEATURES: string[] = [
 	...ES2021_FEATURES,
 	"javascript.builtins.Array.at",
-	"javascript.builtins.String.matchAll",
 	"javascript.classes.public_class_fields",
 	"javascript.classes.private_class_fields",
 	"javascript.classes.private_class_fields_in",


### PR DESCRIPTION
Thank you for the useful library!

I found duplicate matchAll in ES2020 and ES2022.

https://github.com/wessberg/browserslist-generator/blob/0c1ec767ba38407e8a739853831d1017e1d5f01f/src/browserslist-generator/ecma-version.ts#L78

https://github.com/wessberg/browserslist-generator/blob/0c1ec767ba38407e8a739853831d1017e1d5f01f/src/browserslist-generator/ecma-version.ts#L93

By the way, I think the features of ES2020 are lacking. Is this by design?
https://caniuse.com/sr_es11